### PR TITLE
Separete Responsability of provide data from request data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+*.swp

--- a/src/Geocode.php
+++ b/src/Geocode.php
@@ -24,21 +24,7 @@ class Geocode
      */
     private $service_results;
     
-    /**
-     * Address chunks
-     */
-    protected $address = '';
-    protected $latitude = '';
-    protected $longitude = '';
-    protected $country = '';
-    protected $locality = '';
-    protected $district = '';
-    protected $postcode = '';
-    protected $town = '';
-    protected $streetNumber = '';
-    protected $streetAddress = '';
-
-    /**
+   /**
      * Constructor
      *
      * @param string $address The address that is to be parsed
@@ -63,20 +49,19 @@ class Geocode
     }
 
     /**
-     * fetchServiceDetails
+     * get 
      * 
      * Sends request to the passed Google Geocode API URL and fetches the address details and returns them
      * 
      * @param  string $url Google geocode API URL containing the address or latitude/longitude
      * @return bool|object false if no data is returned by URL and the detail otherwise
      */
-    public function fetchServiceDetails($address)
+    public function get($address)
     {
         if (is_null($address)|| $address=="") {
             throw new \Exception("Address is needed");
         }
 
-        $this->address = $address;
         $url= $this->getServiceUrl() . "&address=" . urlencode($address);
         $ch = curl_init();
 
@@ -86,199 +71,8 @@ class Geocode
         $service_results = json_decode(curl_exec($ch));
         if ($service_results && $service_results->status === 'OK') {
             $this->service_results = $service_results;
-            $this->populateAddressVars();
- 
-            return $this->service_results;
+            return new LocationInfo($address, $this->service_results);
         }
-
-        return false;
-    }
-
-    /**
-     * populateAddressVars
-     * 
-     * Populates the address chunks inside the object using the details returned by the service request
-     * 
-     */
-    private function populateAddressVars()
-    {
-        if (!$this->service_results || !$this->service_results->results[0]) {
-            return false;
-        }
-
-        foreach ($this->service_results->results[0]->address_components as $component) {
-            if (in_array('street_number', $component->types)) {
-                $this->streetNumber = $component->long_name;
-            } elseif (in_array('locality', $component->types)) {
-                $this->locality = $component->long_name;
-            } elseif (in_array('postal_town', $component->types)) {
-                $this->town = $component->long_name;
-            } elseif (in_array('administrative_area_level_2', $component->types)) {
-                $this->country = $component->long_name;
-            } elseif (in_array('country', $component->types)) {
-                $this->country = $component->long_name;
-            } elseif (in_array('administrative_area_level_1', $component->types)) {
-                $this->district = $component->long_name;
-            } elseif (in_array('postal_code', $component->types)) {
-                $this->postcode = $component->long_name;
-            } elseif (in_array('route', $component->types)) {
-                $this->streetAddress = $component->long_name;
-            }
-        }
-    }
-
-    /**
-     * getAddress
-     * 
-     * Returns the address if found and the default value otherwise
-     * 
-     * @param string $default Default address that is to be returned if the address is not found
-     * @return string Default address string if no address found and the address otherwise
-     */
-    public function getAddress($default = '')
-    {
-        return $this->address ? $this->address : $default;
-    }
-
-    /**
-     * getLatitude
-     * 
-     * Returns the latitude if found and the default value otherwise
-     * 
-     * @param string $default Default latitude that is to be returned if the latitude is not found
-     * @return string|float Default latitude if no latitude found and the latitude otherwise
-     */
-    public function getLatitude($default = '')
-    {
-        return $this->latitude ? $this->latitude : $default;
-    }
-
-    /**
-     * getLongitude
-     * 
-     * Returns the longitude if found and the default value otherwise
-     * 
-     * @param string $default Default longitude that is to be returned if the longitude is not found
-     * @return string|float Default longitude if no longitude found and the longitude otherwise
-     */
-    public function getLongitude($default = '')
-    {
-        return $this->longitude ? $this->longitude : $default;
-    }
-
-    /**
-     * getCountry
-     * 
-     * Returns the country if found and the default value otherwise
-     * 
-     * @param string $default Default country that is to be returned if the country is not found
-     * @return string Default country string if no country found and the country otherwise
-     */
-    public function getCountry($default = '')
-    {
-        return $this->country ? $this->country : $default;
-    }
-
-    /**
-     * getLocality
-     * 
-     * Returns the locality/country if found and the default value otherwise
-     * 
-     * @param string $default Default locality/country that is to be returned if the locality/country is not found
-     * @return string Default locality/country string if no locality/country found and the locality/country otherwise
-     */
-    public function getLocality($default = '')
-    {
-        return $this->locality ? $this->locality : $default;
-    }
-
-    /**
-     * getDistrict
-     * 
-     * Returns the district if found and the default value otherwise
-     * 
-     * @param string $default Default district that is to be returned if the district is not found
-     * @return string Default district string if no district found and the district otherwise
-     */
-    public function getDistrict($default = '')
-    {
-        return $this->district ? $this->district : $default;
-    }
-
-    /**
-     * getPostcode
-     * 
-     * Returns the postcode if found and the default value otherwise
-     * 
-     * @param string $default Default postcode that is to be returned if the postcode is not found
-     * @return string Default postcode string if no postcode found and the postcode otherwise
-     */
-    public function getPostcode($default = '')
-    {
-        return $this->postcode ? $this->postcode : $default;
-    }
-
-    /**
-     * getTown
-     * 
-     * Returns the town if found and the default value otherwise
-     * 
-     * @param string $default Default town that is to be returned if the town is not found
-     * @return string Default town string if no town found and the town otherwise
-     */
-    public function getTown($default = '')
-    {
-        return $this->town ? $this->town : $default;
-    }
-
-    /**
-     * getStreetNumber
-     * 
-     * Returns the street number if found and the default value otherwise
-     * 
-     * @param string $default Default street number that is to be returned if the street number is not found
-     * @return string Default street number if no street number found and the actual street number otherwise
-     */
-    public function getStreetNumber($default = '')
-    {
-        return $this->streetNumber ? $this->streetNumber : $default;
-    }
-
-    /**
-     * getStreetAddress
-     * 
-     * Returns the address if found and the default value otherwise
-     * 
-     * @param string $default Default address that is to be returned if the address is not found
-     * @return string Default address string if no address found and the address otherwise
-     */
-    public function getStreetAddress($default = '')
-    {
-        return $this->streetAddress ? $this->streetAddress : $default;
-    }
-
-    /**
-     * @return string the object in string format
-     */
-    public function __toString()
-    {
-        $methods = array(
-            'getAddress' => 'Address',
-            'getLatitude' => 'Latitude',
-            'getLongitude' => 'Longitude',
-            'getCountry' => 'Country',
-            'getLocality' => 'Locality',
-            'getDistrict' => 'District',
-            'getPostcode' => 'Postal Code',
-            'getStreetAddress' => 'Street Address',
-            'getStreetNumber' => 'Street Number'
-        );
-
-        $formattedString = '';
-        foreach ($methods as $method => $label) {
-            $formattedString .= $label.' =>'.$method.'<br/>';
-        }
-
-        return $formattedString;
+        return new LocationInfo($address, new \StdClass);
     }
 }

--- a/src/Geocode.php
+++ b/src/Geocode.php
@@ -33,10 +33,10 @@ class Geocode
      */
     public function __construct($key = null)
     {
-       $this->service_url = (!is_null($key))
+        $this->service_url = (!is_null($key))
             ? 'https' . $this->service_url."key={$key}"
             : 'http' . $this->service_url;
-   }
+    }
 
     /**
      * Returns the private $service_url

--- a/src/Geocode.php
+++ b/src/Geocode.php
@@ -45,18 +45,12 @@ class Geocode
      * @param boolean $secure_protocol true if you need to use HTTPS and false otherwise (Defaults to false)
      * @param string $key GMAPS API KEY
      */
-    public function __construct($address, $secure_protocol = false, $key = null)
+    public function __construct($key = null)
     {
-        if (is_null($address)|| $address=="") {
-            throw new \Exception("Address is needed");
-        }
-        $this->service_url = ($secure_protocol|| !is_null($key))
-            ? 'https' . $this->service_url
+       $this->service_url = (!is_null($key))
+            ? 'https' . $this->service_url."key={$key}"
             : 'http' . $this->service_url;
-        $this->service_url .= (is_null($key))?"":"key={$key}";
-        $this->service_results = $this->fetchServiceDetails($address);
-        $this->populateAddressVars();
-    }
+   }
 
     /**
      * Returns the private $service_url
@@ -76,8 +70,12 @@ class Geocode
      * @param  string $url Google geocode API URL containing the address or latitude/longitude
      * @return bool|object false if no data is returned by URL and the detail otherwise
      */
-    private function fetchServiceDetails($address)
+    public function fetchServiceDetails($address)
     {
+        if (is_null($address)|| $address=="") {
+            throw new \Exception("Address is needed");
+        }
+
         $this->address = $address;
         $url= $this->getServiceUrl() . "&address=" . urlencode($address);
         $ch = curl_init();
@@ -87,7 +85,10 @@ class Geocode
         
         $service_results = json_decode(curl_exec($ch));
         if ($service_results && $service_results->status === 'OK') {
-            return $service_results;
+            $this->service_results = $service_results;
+            $this->populateAddressVars();
+ 
+            return $this->service_results;
         }
 
         return false;

--- a/src/LocationInfo.php
+++ b/src/LocationInfo.php
@@ -1,7 +1,7 @@
 <?php
 namespace kamranahmedse;
 
-class LocationInfo 
+class LocationInfo
 {
     private $address = '';
     private $latitude = '';
@@ -14,7 +14,7 @@ class LocationInfo
     private $streetNumber = '';
     private $streetAddress = '';
 
-    private $isValidInfo = true; 
+    private $isValidInfo = true;
 
     public function __construct($address, \stdClass $dataFromGoogleMaps)
     {
@@ -34,7 +34,7 @@ class LocationInfo
             return;
         }
         $this->latitude = $info->results[0]->geometry->location->lat;
-        $this->longitude = $info->results[0]->geometry->location->lng;        
+        $this->longitude = $info->results[0]->geometry->location->lng;
         foreach ($info->results[0]->address_components as $component) {
             if (in_array('street_number', $component->types)) {
                 $this->streetNumber = $component->long_name;
@@ -106,5 +106,3 @@ class LocationInfo
         return $this->streetAddress;
     }
 }
-
-

--- a/src/LocationInfo.php
+++ b/src/LocationInfo.php
@@ -1,0 +1,110 @@
+<?php
+namespace kamranahmedse;
+
+class LocationInfo 
+{
+    private $address = '';
+    private $latitude = '';
+    private $longitude = '';
+    private $country = '';
+    private $locality = '';
+    private $district = '';
+    private $postcode = '';
+    private $town = '';
+    private $streetNumber = '';
+    private $streetAddress = '';
+
+    private $isValidInfo = true; 
+
+    public function __construct($address, \stdClass $dataFromGoogleMaps)
+    {
+        $this->address = $address;
+        $this->mapKeys($dataFromGoogleMaps);
+    }
+
+    public function isValid()
+    {
+        return $this->isValidInfo;
+    }
+
+    private function mapKeys(\stdClass $info)
+    {
+        if (!property_exists($info, 'results')) {
+            $this->isValidInfo = false;
+            return;
+        }
+        $this->latitude = $info->results[0]->geometry->location->lat;
+        $this->longitude = $info->results[0]->geometry->location->lng;        
+        foreach ($info->results[0]->address_components as $component) {
+            if (in_array('street_number', $component->types)) {
+                $this->streetNumber = $component->long_name;
+            } elseif (in_array('locality', $component->types)) {
+                $this->locality = $component->long_name;
+            } elseif (in_array('postal_town', $component->types)) {
+                $this->town = $component->long_name;
+            } elseif (in_array('administrative_area_level_2', $component->types)) {
+                $this->country = $component->long_name;
+            } elseif (in_array('country', $component->types)) {
+                $this->country = $component->long_name;
+            } elseif (in_array('administrative_area_level_1', $component->types)) {
+                $this->district = $component->long_name;
+            } elseif (in_array('postal_code', $component->types)) {
+                $this->postcode = $component->long_name;
+            } elseif (in_array('route', $component->types)) {
+                $this->streetAddress = $component->long_name;
+            }
+        }
+    }
+
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    public function getLatitude()
+    {
+        return $this->latitude;
+    }
+
+    public function getLongitude()
+    {
+        return $this->longitude;
+    }
+
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    public function getLocality()
+    {
+        return $this->locality;
+    }
+
+    public function getDistrict()
+    {
+        return $this->district;
+    }
+
+    public function getPostcode()
+    {
+        return $this->postcode;
+    }
+
+    public function getTown()
+    {
+        return $this->town;
+    }
+
+    public function getStreetNumber()
+    {
+        return $this->streetNumber;
+    }
+
+    public function getStreetAddress()
+    {
+        return $this->streetAddress;
+    }
+}
+
+

--- a/tests/GeocodeTest.php
+++ b/tests/GeocodeTest.php
@@ -11,13 +11,22 @@ class GeocodeTest extends \PHPUnit_Framework_TestCase
     public function testGeocode($address, $expected)
     {
         $actual = new Geocode();
-        $actual->fetchServiceDetails($address);
+        $location = $actual->get($address);
         $methods = array_keys($expected);
+        $this->assertTrue($location->isValid());
         foreach ($methods as $method) {
-            $this->assertEquals($expected[$method], $actual->$method());
+            $this->assertEquals($expected[$method], $location->$method());
         }
     }
 
+
+    public function testInvalidLocation()
+    {
+        $geo= new Geocode();
+        $location = $geo->get("House of the rights for the poor people");
+        $this->assertFalse($location->isValid());
+ 
+    }
     /**
     *@test
     *@expectedException \Exception
@@ -26,7 +35,7 @@ class GeocodeTest extends \PHPUnit_Framework_TestCase
     public function testEmptyOrNullAdress()
     {
         $actual = new Geocode();
-        $actual->fetchServiceDetails("");
+        $actual->get("");
     }
 
     public function testGeocodeProtocol()

--- a/tests/GeocodeTest.php
+++ b/tests/GeocodeTest.php
@@ -10,8 +10,8 @@ class GeocodeTest extends \PHPUnit_Framework_TestCase
      */
     public function testGeocode($address, $expected)
     {
-        $actual = new Geocode($address);
-
+        $actual = new Geocode();
+        $actual->fetchServiceDetails($address);
         $methods = array_keys($expected);
         foreach ($methods as $method) {
             $this->assertEquals($expected[$method], $actual->$method());
@@ -25,33 +25,34 @@ class GeocodeTest extends \PHPUnit_Framework_TestCase
     */
     public function testEmptyOrNullAdress()
     {
-        $actual = new Geocode("");
+        $actual = new Geocode();
+        $actual->fetchServiceDetails("");
     }
 
     public function testGeocodeProtocol()
     {
-        $actual = new Geocode('ADDR', false);
+        $actual = new Geocode();
         $this->assertEquals(
             'http://maps.googleapis.com/maps/api/geocode/json?',
             $actual->getServiceUrl()
         );
 
-        $actual = new Geocode('ADDR', true);
+        $actual = new Geocode();
         $this->assertEquals(
-            'https://maps.googleapis.com/maps/api/geocode/json?',
+            'http://maps.googleapis.com/maps/api/geocode/json?',
             $actual->getServiceUrl()
         );
     }
 
     public function testGeocodeKey()
     {
-        $actual = new Geocode('ADDR', false, 'DUMMYKEY');
+        $actual = new Geocode('DUMMYKEY');
         $this->assertEquals(
             'https://maps.googleapis.com/maps/api/geocode/json?key=DUMMYKEY',
             $actual->getServiceUrl()
         );
 
-        $actual = new Geocode('ADDR', true, 'DUMMYKEY');
+        $actual = new Geocode('DUMMYKEY');
         $this->assertEquals(
             'https://maps.googleapis.com/maps/api/geocode/json?key=DUMMYKEY',
             $actual->getServiceUrl()


### PR DESCRIPTION

I move the responsability of provide data about the location to another
class so we can handle the request at Geocode class and handle the parse 
of the data into locationIfno

basicly we have the same behavior
    - create a instance of GeoCode
        use get instead of fetchServiceDetails 
        (because we GET the Location from GeoCode Resource)
and the answers is a LocationInfo
    - request data with the same interface to avoid a impact big then 
      necessary in the clients